### PR TITLE
generate HTML coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 lib
 .nyc_output
 node_modules
+coverage

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "coverage": "nyc --reporter text-lcov --require babel-core/register mocha | coveralls",
     "prepublish": "npm run build",
     "pretest": "standard ./src/*.js",
-    "test": "nyc --require babel-core/register mocha"
+    "test": "nyc --reporter lcov --reporter text --require babel-core/register mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
this is primarily so that yarsay provides a better smoke test for nyc's source-map support.